### PR TITLE
fix: upgrade web-scripts@2.1.2 and update env vars

### DIFF
--- a/.env
+++ b/.env
@@ -2,6 +2,6 @@
 IMAGE_INLINE_SIZE_LIMIT=0 # Local data URIs are not supported in Phaser 3.
 
 # Custom environment variables.
-WEB_APP_HOMEPAGE=$npm_package_homepage
-WEB_APP_PHASER_VERSION=$npm_package_dependencies_phaser
+WEB_APP_NAME=$npm_package_name
 WEB_APP_VERSION=$npm_package_version
+WEB_APP_PHASER_VERSION=3.52.0

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,5 +1,8 @@
 {
-  "extends": ["@descriptive/web-app", "@descriptive/web-app/jest"],
+  "extends": [
+    "@descriptive/eslint-config-web-app",
+    "@descriptive/eslint-config-web-app/jest"
+  ],
   "plugins": ["prettier"],
   "rules": {
     "no-debugger": "error",

--- a/package.json
+++ b/package.json
@@ -16,14 +16,13 @@
     "test:ci": "CI=true npm test -- --passWithNoTests",
     "postinstall": "husky install"
   },
-  "homepage": "https://remarkablegames.org/phaser-template/",
   "dependencies": {
     "phaser": "3.52.0"
   },
   "devDependencies": {
     "@commitlint/cli": "^11.0.0",
     "@commitlint/config-conventional": "^11.0.0",
-    "@descriptive/web-scripts": "2.0.3",
+    "@descriptive/web-scripts": "2.1.2",
     "eslint-plugin-prettier": "^3.3.1",
     "gitploy": "0.1.0",
     "husky": "^7.0.4",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "standard-version": "^9.1.0"
   },
   "engines": {
-    "node": "^10.12.0 || >=12.0.0"
+    "node": ">=14.0.0"
   },
   "private": true,
   "license": "MIT"

--- a/src/index.js
+++ b/src/index.js
@@ -8,8 +8,8 @@ const config = {
   width: 800,
   height: 600,
   title: 'Phaser Template',
+  url: 'https://remarkablegames.org/phaser-template/',
   // see `.env` and `package.json`
-  url: process.env.WEB_APP_HOMEPAGE,
   version: process.env.WEB_APP_VERSION,
   scene: [Boot, Main],
   physics: {


### PR DESCRIPTION
Upgrade [@descriptive/web-scripts@2.1.2](https://github.com/remarkablemark/descriptive/releases/tag/%40descriptive%2Fweb-scripts%402.1.2), which is [react-scripts@5.0.0](https://github.com/facebook/create-react-app/tree/v5.0.0/packages/react-scripts)

Update `.env` for vars that no longer show up in npm env:

```sh
$ npm -v
7.21.0
$ npm run env | grep npm_package_
npm_package_json=path/to/package.json
npm_package_name=phaser-template
npm_package_engines_node=^10.12.0 || >=12.0.0
npm_package_version=1.0.0-alpha
```