### PR TITLE
fix(vite): disable inlining of assets

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -18,10 +18,10 @@ new Phaser.Game({
       gravity: {
         y: 300,
       },
-      debug: import.meta.env.PROD,
+      debug: import.meta.env.DEV,
     },
   },
-  disableContextMenu: import.meta.env.DEV,
+  disableContextMenu: import.meta.env.PROD,
   backgroundColor: '#fff',
   scale: {
     mode: Phaser.Scale.FIT,

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+  build: {
+    assetsInlineLimit: 0,
+  },
+});


### PR DESCRIPTION
https://vitejs.dev/config/build-options#build-assetsinlinelimit

Fix Phaser error:

```
Local data URIs are not supported
```

Relates to:

- #432